### PR TITLE
opal-node can't find ./app.rb

### DIFF
--- a/bin/opal-node
+++ b/bin/opal-node
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 require('../lib/opal');
-// Remove any ./ since in node is unnecessary
-require(process.argv[2].replace(/\A\.\//,''));
+scriptPath = require('path').resolve(process.argv[2]);
+require(scriptPath);


### PR DESCRIPTION
I tried opal-node with Node v0.8.17 and v0.9.7, but got the following error:

```
% cat app.rb
puts "hello"
% opal-node app.rb

module.js:340
    throw err;
          ^
Error: Cannot find module 'app.rb'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/usr/local/share/npm/lib/node_modules/opal/bin/opal-node:5:1)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
```

When you call require("foo.rb"), Node will look for somewhere/node_modules/foo.rb.
This patch fixes bin/opal-node to expand the given path based on current working directory.
